### PR TITLE
fixing jnlp.jsp template 

### DIFF
--- a/webstart/webstart.jnlp.jsp.template
+++ b/webstart/webstart.jnlp.jsp.template
@@ -12,6 +12,7 @@
 	String query = request.getQueryString();
 	if(query != null && query.length() > 0)
 	{
+		document += "?" + query;
 		
 		java.net.URL baseURL = new java.net.URL(url.toString());
 		parameters = query.split("&");
@@ -47,22 +48,20 @@
 	</security>
 
 	<application-desc main-class="au.gov.ga.earthsci.application.WebStartMain">
-		<argument>-showsplash</argument>
-<%
+		<%
+		String argumentString = "-showsplash";
 	if(parameters != null)
 	{
 		for(String parameter : parameters)
 		{
 			if(parameter != null && parameter.length() > 0)
 			{
-%>
-		<argument>--open</argument>
-		<argument><%= parameter %></argument>
-<%
+				argumentString += ";;--open;;"+parameter;
 			}
 		}
+		 
 	}
-%>
+%><argument><%= argumentString %></argument>
 	</application-desc>
 
 	<resources>


### PR DESCRIPTION
changed JSP to have all passed parameters contained within a single argument tag to be used by the WebStartMain class.